### PR TITLE
Stop using pstore

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -61,7 +61,6 @@
 #       initializing any expected files and folders.
 -m /dev/mmcblk0p1:/boot:vfat:ro,nodev,noexec,nosuid:
 -m /dev/mmcblk0p3:/root:f2fs:nodev:
--m pstore:/sys/fs/pstore:pstore:nodev,noexec,nosuid:
 -m tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k
 -m cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu
 


### PR DESCRIPTION
> pstore block (pstore/blk) is an oops/panic logger that writes its logs to a block device and non-block device before the system crashes.

refs. https://www.kernel.org/doc/html/latest/admin-guide/pstore-blk.html

nerves_system_rpi* 系で使われているが、以下のようなデバイスツリーとともに使うもので、必ずしも必要でないので今回は採用しない。

https://github.com/nerves-project/nerves_system_rpi3/blob/v1.24.1/ramoops.dts